### PR TITLE
fix: compare BASE with merged state instead of HEAD directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.21.2
+FROM alpine:3.21.3
 
 RUN apk update && apk --no-cache add bash curl git
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG KUSTOMIZE=5.4.3
+ARG KUSTOMIZE=5.6.0
 RUN curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE}/kustomize_v${KUSTOMIZE}_linux_amd64.tar.gz | \
 tar xz && mv kustomize /usr/local/bin/kustomize
 

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ build:
 	docker buildx build --build-arg BUILDPLATFORM=$(BUILDPLATFORM) --build-arg TARGETARCH=$(GOARCH) -t local/$(PROJNAME) .
 
 scan: build
-	trivy --light -s "UNKNOWN,MEDIUM,HIGH,CRITICAL" --exit-code 1 local/$(PROJNAME)
+	trivy image -s "UNKNOWN,MEDIUM,HIGH,CRITICAL" --exit-code 1 local/$(PROJNAME)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Managing Kubernetes configurations across multiple environments and PRs can be c
 ## Features
 
 - Automatically builds Kustomize configurations from both PR branches
-- Generates a diff between base and head configurations
+- Generates a diff showing what would actually change upon merge (not just differences between branches)
+- Intelligently handles parallel changes to base and feature branches
 - Configurable root directory and search depth for Kustomize files
 - Commits must meet [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
   - Automated with GitHub Actions ([commit-lint](https://github.com/conventional-changelog/commitlint/#what-is-commitlint))
@@ -21,6 +22,16 @@ Managing Kubernetes configurations across multiple environments and PRs can be c
   - Automated with GitHub Actions ([pr-lint](https://github.com/amannn/action-semantic-pull-request))
 - Commits must be signed with [Developer Certificate of Origin (DCO)](https://developercertificate.org/)
   - Automated with GitHub App ([DCO](https://github.com/apps/dco))
+
+## How It Works
+Unlike simple diff tools, this action:
+
+1. Builds Kustomize output from the base branch
+1. Creates a temporary merge of the head branch into base (simulating the actual PR merge)
+1. Builds Kustomize output from the merged state
+1. Compares these outputs to show exactly what would change after merging
+
+This approach correctly handles cases where changes have been made to the base branch in parallel to the feature branch, avoiding misleading diffs that incorrectly suggest changes would be reverted.
 
 ## Inputs
 

--- a/kustdiff
+++ b/kustdiff
@@ -39,23 +39,22 @@ function safe_filename() {
   echo "$1" | sed 's/[^a-zA-Z0-9.]/_/g'
 }
 
-function build {
+function build_ref {
   local ref="$1"
-  local safe_ref=$(safe_filename "$ref")
+  local output_dir="$2"
   echo "Checking out ref: $ref"
   git checkout "$ref" --quiet
-  mkdir -p "$TMP_DIR/$safe_ref"
+  mkdir -p "$output_dir"
   for envpath in $(get_targets); do
     local relative_path="${envpath#$ROOT_DIR/}"
     local safe_path=$(safe_filename "$relative_path")
-    local output_file="$TMP_DIR/$safe_ref/${safe_path}.yaml"
+    local output_file="$output_dir/${safe_path}.yaml"
     echo "Running kustomize for $envpath"
     kustomize build "$envpath" -o "$output_file"
 
-#    debug_log "Contents of $output_file:"
-#    debug_log "$(cat "$output_file")"
-#    debug_log "End of $output_file"
-#    debug_log "------------------------------------"
+    if [ "$DEBUG" = "true" ]; then
+      debug_log "Built kustomize for $envpath to $output_file"
+    fi
   done
 }
 
@@ -65,29 +64,56 @@ function main {
   validate_max_depth
 
   git config --global --add safe.directory "$GITHUB_WORKSPACE"
-  local diff escaped_output output
-  build "$INPUT_HEAD_REF"
-  build "$INPUT_BASE_REF"
 
-  local safe_head_ref=$(safe_dirname "$INPUT_HEAD_REF")
-  local safe_base_ref=$(safe_dirname "$INPUT_BASE_REF")
+  # Save current state to restore later
+  local current_branch
+  current_branch=$(git rev-parse --abbrev-ref HEAD)
 
+  # Build BASE output
+  local safe_base_ref=$(safe_filename "$INPUT_BASE_REF")
+  local base_output_dir="$TMP_DIR/base"
+  build_ref "$INPUT_BASE_REF" "$base_output_dir"
+
+  # Create a temporary merge branch
+  local merge_branch="temp-merge-$RANDOM"
+  git checkout -b "$merge_branch" "$INPUT_BASE_REF" --quiet
+
+  debug_log "Creating temporary merge of $INPUT_HEAD_REF into $INPUT_BASE_REF"
+
+  # Attempt to merge HEAD into BASE
+  if ! git merge "$INPUT_HEAD_REF" --quiet; then
+    echo "Merge conflict detected. Cannot automatically merge $INPUT_HEAD_REF into $INPUT_BASE_REF."
+    git merge --abort
+    git checkout "$current_branch" --quiet
+    exit 1
+  fi
+
+  # Build merged output
+  local merged_output_dir="$TMP_DIR/merged"
+  build_ref "$merge_branch" "$merged_output_dir"
+
+  # Compare outputs
   set +e
-  diff=$(git diff --no-index "$TMP_DIR/$safe_base_ref" "$TMP_DIR/$safe_head_ref")
+  diff=$(git diff --no-index "$base_output_dir" "$merged_output_dir")
+  local diff_exit_code=$?
 
   debug_log "Git diff output:"
   debug_log "$diff"
   debug_log "End of git diff output"
   debug_log "------------------------------------"
 
-  if [[ -z "$diff" ]]; then
-    output="No differences found between $INPUT_BASE_REF and $INPUT_HEAD_REF"
+  # Clean up temporary branches
+  git checkout "$current_branch" --quiet
+  git branch -D "$merge_branch" --quiet
+
+  if [[ $diff_exit_code -eq 0 ]]; then
+    output="No differences found in kustomize output after merging $INPUT_HEAD_REF into $INPUT_BASE_REF"
   else
     # Just pass through the raw git diff output
     output="$diff"
   fi
 
-  escaped_output=${output//$'\n'/'%0A'}
+  local escaped_output=${output//$'\n'/'%0A'}
 
   if [ ${#escaped_output} -gt 65000 ]; then
     escaped_output="Output is greater than 65000 characters, and therefore too large to print as a github comment."


### PR DESCRIPTION
This PR addresses issue #11, where the action incorrectly indicated that changes to the BASE branch would be reverted when the PR is merged.

## Problem
The previous implementation compared the kustomize output from the BASE branch directly with the HEAD branch. This approach fails to account for git's merge behaviour and can lead to misleading diffs:
```
Old Base -> BASE
         \
           -> HEAD
```
When someone creates a feature branch without first pulling the latest changes, parallel changes made to BASE would appear as if they would be reverted by the PR, even though git's actual merge behavior would preserve them.


## Solution
Instead of comparing BASE with HEAD directly, this PR:

1. Builds the kustomize output for the BASE branch
2. Creates a temporary merge branch from BASE
3. Merges HEAD into this temporary branch (simulating what git would do during PR merge)
4. It builds the kustomize output for the merged state
5. Compares the BASE output with the merged output

This approach shows only the changes introduced by merging the PR, providing a more accurate representation of the final state.

## Additional Improvements

1. Added proper merge conflict detection and handling
2. Improved cleanup of temporary git branches
3. Enhanced debug logging for the merge process
4. Maintained backward compatibility with existing input parameters

Closes #11

## How has this been tested?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/swade1987/flux2-kustomize-template/blob/main/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
