### PR TITLE
fix: improve branch reference handling and compare with merged state

### DIFF
--- a/kustdiff
+++ b/kustdiff
@@ -39,6 +39,14 @@ function safe_filename() {
   echo "$1" | sed 's/[^a-zA-Z0-9.]/_/g'
 }
 
+function git_with_error_handling() {
+  if ! "$@"; then
+    echo "Error executing git command: $*"
+    return 1
+  fi
+  return 0
+}
+
 function build_ref {
   local ref="$1"
   local output_dir="$2"
@@ -63,28 +71,65 @@ function main {
   validate_root_dir
   validate_max_depth
 
-  git config --global --add safe.directory "$GITHUB_WORKSPACE"
+  git_with_error_handling git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
   # Save current state to restore later
   local current_branch
-  current_branch=$(git rev-parse --abbrev-ref HEAD)
+  current_branch=$(git rev-parse --abbrev-ref HEAD || echo "detached")
+
+  # Check if the branch exists locally or as a remote reference
+  function resolve_branch_ref() {
+    local branch_name="$1"
+
+    # First check if it's a local branch
+    if git show-ref --verify --quiet "refs/heads/$branch_name"; then
+      echo "$branch_name"
+      return 0
+    fi
+
+    # Next check if it's a remote branch
+    if git show-ref --verify --quiet "refs/remotes/origin/$branch_name"; then
+      echo "origin/$branch_name"
+      return 0
+    fi
+
+    # Finally check if it's a valid commit SHA
+    if git cat-file -e "$branch_name^{commit}" 2>/dev/null; then
+      echo "$branch_name"
+      return 0
+    fi
+
+    # If we get here, we couldn't resolve the reference
+    echo "Error: Could not resolve reference: $branch_name"
+    return 1
+  }
+
+  # Resolve the BASE and HEAD references
+  local base_ref_resolved
+  base_ref_resolved=$(resolve_branch_ref "$INPUT_BASE_REF") || exit 1
+  debug_log "Resolved base reference: $base_ref_resolved (from $INPUT_BASE_REF)"
 
   # Build BASE output
   local safe_base_ref=$(safe_filename "$INPUT_BASE_REF")
   local base_output_dir="$TMP_DIR/base"
-  build_ref "$INPUT_BASE_REF" "$base_output_dir"
+  build_ref "$base_ref_resolved" "$base_output_dir"
+
+  # Resolve HEAD reference
+  local head_ref_resolved
+  head_ref_resolved=$(resolve_branch_ref "$INPUT_HEAD_REF") || exit 1
+  debug_log "Resolved head reference: $head_ref_resolved (from $INPUT_HEAD_REF)"
 
   # Create a temporary merge branch
   local merge_branch="temp-merge-$RANDOM"
-  git checkout -b "$merge_branch" "$INPUT_BASE_REF" --quiet
+  git checkout -b "$merge_branch" "$base_ref_resolved" --quiet
 
-  debug_log "Creating temporary merge of $INPUT_HEAD_REF into $INPUT_BASE_REF"
+  debug_log "Creating temporary merge of $head_ref_to_use into $base_ref_to_use (via $merge_branch)"
 
   # Attempt to merge HEAD into BASE
-  if ! git merge "$INPUT_HEAD_REF" --quiet; then
-    echo "Merge conflict detected. Cannot automatically merge $INPUT_HEAD_REF into $INPUT_BASE_REF."
-    git merge --abort
-    git checkout "$current_branch" --quiet
+  if ! git merge "$head_ref_to_use" --quiet; then
+    echo "Merge conflict detected. Cannot automatically merge $head_ref_to_use into $base_ref_to_use."
+    git merge --abort || true
+    git checkout "$current_branch" --quiet || git checkout "$base_ref_to_use" --quiet || true
     exit 1
   fi
 
@@ -94,17 +139,18 @@ function main {
 
   # Compare outputs
   set +e
-  diff=$(git diff --no-index "$base_output_dir" "$merged_output_dir")
+  diff=$(git diff --no-index "$base_output_dir" "$merged_output_dir" 2>&1)
   local diff_exit_code=$?
 
+  debug_log "Git diff exit code: $diff_exit_code"
   debug_log "Git diff output:"
   debug_log "$diff"
   debug_log "End of git diff output"
   debug_log "------------------------------------"
 
   # Clean up temporary branches
-  git checkout "$current_branch" --quiet
-  git branch -D "$merge_branch" --quiet
+  git checkout "$current_branch" --quiet || git checkout "$base_ref_to_use" --quiet || true
+  git branch -D "$merge_branch" --quiet || true
 
   if [[ $diff_exit_code -eq 0 ]]; then
     output="No differences found in kustomize output after merging $INPUT_HEAD_REF into $INPUT_BASE_REF"


### PR DESCRIPTION
This PR addresses an issue where the kustomize-diff action would fail when trying to create and merge temporary branches.

**Problem**
The action was attempting to compare BASE with the result of merging HEAD into BASE (which is the correct approach), but was failing with:
```
 printf '[DEBUG] %s \n' 'Creating temporary merge of test into main'
+ git merge test --quiet
merge: test - not something we can merge

Did you mean this?
	origin/test
+ echo 'Merge conflict detected. Cannot automatically merge test into main.'
Merge conflict detected. Cannot automatically merge test into main.
+ git merge --abort
fatal: There is no merge to abort (MERGE_HEAD missing).
```
This occurred because:

1. GitHub Actions often use detached HEAD states
2. Branch references need to handle both local and remote formats (e.g., main vs origin/main)
3. Sometimes GitHub provides commit SHAs instead of branch names

**Solution**
Implemented robust branch reference resolution that:
- Correctly detects whether a reference is available as a local branch, remote branch, or direct commit SHA
- Resolves references to their correct format before attempting checkout or merge operations
- Handles the detached HEAD state common in GitHub Actions environments

This fix enables the action to correctly implement the "compare with merged state" approach as initially intended, ensuring accurate diffs are displayed in PR comments.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/swade1987/flux2-kustomize-template/blob/main/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
