### PR TITLE
fix: improve branch reference handling and git identity

### DIFF
--- a/kustdiff
+++ b/kustdiff
@@ -63,6 +63,10 @@ function main {
   validate_root_dir
   validate_max_depth
 
+  # Set up git identity for merge operations
+  git config --global user.email "github-actions@github.com" || true
+  git config --global user.name "GitHub Actions" || true
+
   git config --global --add safe.directory "$GITHUB_WORKSPACE" || true
 
   # Save current state to restore later


### PR DESCRIPTION
## Description
This PR addresses an issue where the kustomize-diff action fails when attempting to perform merge operations in GitHub Actions environments.

## Problem
The action was correctly attempting to compare BASE with the result of merging HEAD into BASE (which shows the actual changes that would occur upon merge), but was failing with the following error:

```
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'root@a31666a14df2.(none)')
```

## This issue occurs because:
- Git requires a user identity (name and email) to be configured before it can create commits
- The merge operation in the script implicitly creates a commit
- GitHub Actions runners don't have git user identity configured by default

## Solution
Added git identity configuration:
- Set up a default git user email and name for GitHub Actions
- Makes merge operations possible in CI environments without user interaction

## How has this been tested?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/swade1987/flux2-kustomize-template/blob/main/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
