### PR TITLE
feat: add automatic Helm chart support detection

### DIFF
--- a/kustdiff
+++ b/kustdiff
@@ -50,7 +50,15 @@ function build_ref {
     local safe_path=$(safe_filename "$relative_path")
     local output_file="$output_dir/${safe_path}.yaml"
     echo "Running kustomize for $envpath"
-    kustomize build "$envpath" -o "$output_file"
+
+    # Check if kustomization.yaml contains helmCharts
+    local helm_flag=""
+    if grep -q "helmCharts:" "$envpath/kustomization.yaml"; then
+      debug_log "Helm charts detected in $envpath, enabling Helm support"
+      helm_flag="--enable-helm"
+    fi
+
+    kustomize build $helm_flag "$envpath" -o "$output_file"
 
     if [ "$DEBUG" = "true" ]; then
       debug_log "Built kustomize for $envpath to $output_file"


### PR DESCRIPTION
## Description
This PR addresses an issue where the kustomize-diff action fails when processing kustomization files that include Helm charts.

## Problem
When a `kustomization.yaml` file includes the `helmCharts` field, the action would fail with the following error:

```
`: must specify --enable-helm
This happens because Kustomize requires an explicit --enable-helm flag when building configurations that include Helm charts.
```

## Solution
This PR adds automatic detection of Helm charts in kustomization files by:

1. Checking for the presence of `helmCharts`: in each kustomization file
2. Automatically adding the `--enable-helm` flag when needed
3. Preserving the original behaviour for `kustomization` files that don't use Helm charts

## Benefits

1. Zero configuration: Users don't need to set any additional parameters
2. Backwards compatible: No changes required for existing workflows
3. Future proof: Works with mixed environments where only some kustomization files use Helm charts
4. Transparent: Adds debug logging when Helm support is enabled

This change makes the action more robust and able to handle a wider variety of Kustomize configurations without user intervention.

## How has this been tested?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/swade1987/flux2-kustomize-template/blob/main/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

## Towards/Closes
Towards #12 
