### PR TITLE
feat: bump kustomize to v5.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk --no-cache add bash curl git
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG KUSTOMIZE=5.6.0
+ARG KUSTOMIZE=5.7.0
 RUN curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE}/kustomize_v${KUSTOMIZE}_linux_amd64.tar.gz | \
 tar xz && mv kustomize /usr/local/bin/kustomize
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
bump kustomize to 5.7.0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it works towards an open issue, please link to the issue here. -->
We use replacements in out setup, and received an error when running this action, but didn't when running kustomize build locally.
This is due to our usage of "sourceValue" in replacements which was added in [5.7.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.7.0).

## How has this been tested?
Yes. 
In my own private repo, I pointed the workflow to my version of the action, and I've seen the action complete successfully. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/swade1987/flux2-kustomize-template/blob/main/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
